### PR TITLE
Removing duplicated instance label

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -49,7 +49,6 @@ Selector labels
 */}}
 {{- define "spaceone.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "spaceone.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
helpers.tpl contain a duplicated app.kubernetes.io/instance label both in "Common labels" and in "Selector labels" (there is an include which adds them together) which causes an error: Failed to get helm release resources: YAMLException: duplicated mapping key (FluxCD)
